### PR TITLE
Env replace in runner config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ Each supported hook can also be specified by a configuration file `<hookName>.ya
 
 ```yaml
 # The command to run.
-cmd: "my-command.exe"
+cmd: "command-of-${env:USER}.exe"
 
 # The arguments given to `cmd`.
 args:
   - "-s"
   - "--all"
+  - "${env:GPG_PUBLIC_KEY}"
+  - "--test ${git-l:my-local-git-config-var}"
 
 # If you want to make sure your file is not
 # treated always as the newest version. Fix the version by:
@@ -112,9 +114,18 @@ version: 1
 ```
 
 All additional arguments given by Git to `<hookName>` will be appended last onto `args`.
-@todo: Describe Env and Git config replacment.
+All environment and Git config variables in `args` and `cmd` are substituted with the following syntax:
 
-**Sidenote**: You might ask why we split this configuration into one for each hook instead of one collocated YAML file. The reason is that each hook invocation by Git is separate. Avoiding reading this total file several times needs time and since we want speed and only an opt-in solution this is avoided.
+- `${env:VAR}` : Denotes an environment variable `VAR`.
+- `${git:VAR}` : Denotes an Git config variable `VAR` which corresponds to `git config 'VAR'`.
+- `${git-l:VAR}` : Denotes an Git config variable `VAR` which corresponds to `git config --local 'VAR'`.
+- `${git-g:VAR}` : Denotes an Git config variable `VAR` which corresponds to `git config --global 'VAR'`.
+- `${git-s:VAR}` : Denotes an Git config variable `VAR` which corresponds to `git config --system 'VAR'`.
+
+Not existing environment variables or Git config variables are replaced with the empty string by default. If you use `${!...:VAR}` (e.g `${!git-s:VAR }`) it will trigger an error and fail the hook if the variable `VAR` is not found.
+Escaping a above syntax works with `\${...}`.
+
+**Sidenote**: You might wonder why this configuration is not collocated in one YAML file for all hooks. The reason is that each hook invocation by Git is separate. Avoiding reading this total file several times needs time and since we want speed and only an opt-in solution this is avoided.
 
 ## Supported Hooks
 

--- a/docs/cli/git_hooks.md
+++ b/docs/cli/git_hooks.md
@@ -4,7 +4,7 @@ Githooks CLI application
 
 ### Synopsis
 
-See further information at https://github.com/rycus86/githooks/blob/master/README.md
+See further information at https://github.com/gabyx/githooks/blob/master/README.md
 
 ```
 git hooks

--- a/githooks/go.mod
+++ b/githooks/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	code.gitea.io/sdk/gitea v0.13.2
+	github.com/agext/regexp v1.3.0
 	github.com/bmatcuk/doublestar/v3 v3.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/goccy/go-yaml v1.8.2
@@ -21,7 +22,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/sys v0.0.0-20201113135734-0a15ea8d9b02
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221

--- a/githooks/go.sum
+++ b/githooks/go.sum
@@ -17,6 +17,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/agext/regexp v1.3.0 h1:6+9tp+S41TU48gFNV47bX+pp1q7WahGofw6JccmsCDs=
+github.com/agext/regexp v1.3.0/go.mod h1:6phv1gViOJXWcTfpxOi9VMS+MaSAo+SUDf7do3ur1HA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/githooks/hooks/runner_test.go
+++ b/githooks/hooks/runner_test.go
@@ -1,0 +1,83 @@
+package hooks
+
+import (
+	"gabyx/githooks/git"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getGitConfig(key string, scope git.ConfigScope) (string, bool) {
+	if key == "one.one" {
+		return "", false
+	}
+
+	s := string(scope)
+	if scope == git.Traverse {
+		s = "--traverse"
+	}
+
+	return key + s, true
+}
+
+func TestEnvReplace(t *testing.T) {
+
+	subst := getEnvSubstitution(os.LookupEnv, getGitConfig)
+
+	os.Setenv("var", "banana")
+	os.Setenv("tar", "monkey")
+
+	var r string
+	var err error
+
+	r, err = subst(`${var}`)
+	assert.Equal(t, `${var}`, r, "Should not have been replaced.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`\${var}`)
+	assert.Equal(t, `\${var}`, r, "Should not have been replaced.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${env:gar}`)
+	assert.Equal(t, "", r, "Replace non existent env. var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${env:var}`)
+	assert.Equal(t, "banana", r, "Replace existent env. var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${env:var} ${env:tar}`)
+	assert.Equal(t, "banana monkey", r, "Replace existent env. var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${git:one.one}`)
+	assert.Equal(t, "", r, "Replace non existent Git var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${!git:one.one}`)
+	assert.Equal(t, "", r, "Replace non existent Git var.")
+	assert.NotNil(t, err, "Need an error.")
+
+	r, err = subst(`${git:two}`)
+	assert.Equal(t, "two--traverse", r, "Replace existent Git var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${git-l:two}`)
+	assert.Equal(t, "two--local", r, "Replace existent Git var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${git-g:two}`)
+	assert.Equal(t, "two--global", r, "Replace existent Git var.")
+	assert.Nil(t, err, "No error.")
+
+	r, err = subst(`${env:var} '${git-l:one.one}' ${git-l:two} ${git-g:two} ${git-s:two}`)
+	assert.Equal(t, "banana '' two--local two--global two--system", r, "Replace existent Env and Git var.")
+	assert.Nil(t, err, "No error.")
+
+	// Test some error replacements
+	r, err = subst(`'${git-l:one.one}' ${git-l:two} ${git-g:two} ${git-s:two} '${!env:nonexistentenvvar}'`)
+	assert.Equal(t, "'' two--local two--global two--system ''", r, "Replace existent Env and Git var.")
+	assert.NotNil(t, err, "Need an error.")
+
+}

--- a/githooks/hooks/shared.go
+++ b/githooks/hooks/shared.go
@@ -493,7 +493,7 @@ func GetSharedHookTypeString(sharedType SharedHookType) string {
 	case SharedHookTypeV.Global:
 		return "global"
 	default:
-		cm.DebugAssertF(false, "Wrong type '%s'", sharedType)
+		cm.DebugAssertF(false, "Wrong type '%v'", sharedType)
 
 		return "wrong-value" // nolint:nlreturn
 	}

--- a/tests/exec-testsuite-go.sh
+++ b/tests/exec-testsuite-go.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if ! grep '/docker/' </proc/self/cgroup >/dev/null 2>&1; then
+    echo "! This script is only meant to be run in a Docker container"
+    exit 1
+fi
+
+DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+
+REPO_DIR="$DIR/.."
+GO_SRC="$REPO_DIR/githooks"
+
+cd "$GO_SRC" || exit 1
+
+echo "Go generate ..."
+
+export CGO_ENABLED=0
+
+go mod vendor
+go generate -mod vendor ./...
+
+if ! go test ./...; then
+    echo "Go testsuite reported errors."
+    exit 1
+fi
+
+exit 0

--- a/tests/test-testsuite-go.sh
+++ b/tests/test-testsuite-go.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+cat <<EOF | docker build --force-rm -t githooks:testsuite-go -
+FROM golang:1.15.6-alpine
+RUN apk add git curl git-lfs --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main --allow-untrusted
+RUN apk add bash
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$(go env GOPATH)/bin v1.34.1
+
+EOF
+
+if ! docker run --rm -it -v "$(pwd)":/data -w /data githooks:testsuite-go sh "tests/exec-testsuite-go.sh"; then
+    echo "! Check rules had failures."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Suggestion:

- `${env:....}` -> env
- `${git:....}` -> traverse
- `${git-l:....}` -> local config
- `${git-g:....}` -> global config