### PR TITLE
Honour include directives in git config

### DIFF
--- a/githooks/git/git.go
+++ b/githooks/git/git.go
@@ -56,9 +56,9 @@ func (c *Context) GetConfig(key string, scope ConfigScope) string {
 	var err error
 
 	if scope != Traverse {
-		out, err = c.Get("config", string(scope), key)
+		out, err = c.Get("config", "--includes", string(scope), key)
 	} else {
-		out, err = c.Get("config", key)
+		out, err = c.Get("config", "--includes", key)
 	}
 
 	if err == nil {
@@ -75,9 +75,9 @@ func (c *Context) LookupConfig(key string, scope ConfigScope) (string, bool) {
 	var err error
 
 	if scope != Traverse {
-		out, err = c.Get("config", string(scope), key)
+		out, err = c.Get("config", "--includes", string(scope), key)
 	} else {
-		out, err = c.Get("config", key)
+		out, err = c.Get("config", "--includes", key)
 	}
 
 	if err == nil {
@@ -93,9 +93,9 @@ func (c *Context) getConfigWithArgs(key string, scope ConfigScope, args ...strin
 	var err error
 
 	if scope != Traverse {
-		out, err = c.Get(append(append([]string{"config"}, args...), string(scope), key)...)
+		out, err = c.Get(append(append([]string{"config", "--includes"}, args...), string(scope), key)...)
 	} else {
-		out, err = c.Get(append(append([]string{"config"}, args...), key)...)
+		out, err = c.Get(append(append([]string{"config", "--includes"}, args...), key)...)
 	}
 
 	if err != nil {
@@ -120,7 +120,7 @@ func (c *Context) GetConfigAllU(key string, scope ConfigScope) string {
 // GetConfigRegex gets all Git configuration values for regex `regex`.
 // Returns a list of pairs.
 func (c *Context) GetConfigRegex(regex string, scope ConfigScope) (res [][]string) {
-	configs, err := c.Get("config", string(scope), "--get-regexp", regex)
+	configs, err := c.Get("config", "--includes", string(scope), "--get-regexp", regex)
 
 	if err != nil {
 		return

--- a/tests/test-windows.sh
+++ b/tests/test-windows.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 cat <<'EOF' | docker build --force-rm -t githooks:windows-lfs -f - .
-FROM mcr.microsoft.com/windows/servercore:1809
+FROM mcr.microsoft.com/windows/servercore:2004
 
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]


### PR DESCRIPTION
- E.g. in containers where the root user has a include (`git config
  --global`) to another user's (main user) gitconfig,
  the Githooks install dir is for example not found.
  This fix searches also in includes which
  are defined in the respective scope.