### PR TITLE
Do not abort reference-transaction hook in certain cases :anchor: (#70)

### DIFF
--- a/githooks/apps/runner/runner.go
+++ b/githooks/apps/runner/runner.go
@@ -602,6 +602,11 @@ func checkSharedHook(
 	allAddedHooks *[]string,
 	sharedType hooks.SharedHookType) bool {
 
+	// Aborting a 'reference-transaction' hook (type 'prepared') leads
+	// to all sorts of problems, therefore
+	// do only print an error and continue.
+	isFatal := settings.HookName != "reference-transaction"
+
 	if strs.Includes(*allAddedHooks, hook.RepositoryDir) {
 		log.WarnF(
 			"Shared hooks entry:\n'%s'\n"+
@@ -612,7 +617,7 @@ func checkSharedHook(
 
 	// Check that no local paths are in repository configured
 	// shared hooks
-	log.PanicIfF(!hooks.AllowLocalURLInRepoSharedHooks() &&
+	log.ErrorOrPanicIfF(isFatal, !hooks.AllowLocalURLInRepoSharedHooks() &&
 		sharedType == hooks.SharedHookTypeV.Repo && hook.IsLocal,
 		"Shared hooks in '%[1]s' contain a local path\n"+
 			"'%[2]s'\n"+
@@ -648,7 +653,8 @@ func checkSharedHook(
 			mess += "\nContinuing..."
 		}
 
-		log.ErrorOrPanicF(!settings.SkipNonExistingSharedHooks, err, mess, hook.OriginalURL)
+		log.ErrorOrPanicF(isFatal && !settings.SkipNonExistingSharedHooks,
+			err, mess, hook.OriginalURL)
 
 		return false
 	}
@@ -671,7 +677,7 @@ func checkSharedHook(
 				mess += "\nContinuing..."
 			}
 
-			log.ErrorOrPanicF(!settings.SkipNonExistingSharedHooks,
+			log.ErrorOrPanicF(isFatal && !settings.SkipNonExistingSharedHooks,
 				nil, mess, hook.OriginalURL, url)
 
 			return false

--- a/githooks/common/log.go
+++ b/githooks/common/log.go
@@ -52,6 +52,7 @@ type ILogContext interface {
 
 	// Assert helper functions
 	ErrorOrPanicF(isFatal bool, err error, format string, args ...interface{})
+	ErrorOrPanicIfF(isFatal bool, condition bool, format string, args ...interface{})
 	AssertWarn(condition bool, lines ...string)
 	AssertWarnF(condition bool, format string, args ...interface{})
 	DebugIf(condition bool, lines ...string)

--- a/githooks/common/logasserts.go
+++ b/githooks/common/logasserts.go
@@ -136,3 +136,12 @@ func (c *LogContext) ErrorOrPanicF(isFatal bool, err error, format string, args 
 		}
 	}
 }
+
+// ErrorOrPanicIfF logs an error or a fatal error if the condition is met.
+func (c *LogContext) ErrorOrPanicIfF(isFatal bool, condition bool, format string, args ...interface{}) {
+	if isFatal {
+		c.PanicIfF(condition, format, args...)
+	} else {
+		c.ErrorIfF(condition, format, args...)
+	}
+}


### PR DESCRIPTION
Do not abort `reference-transaction` when shared hooks cannot be found.
Not doing this can leave submodules and other repositories cloned behind the scenes in a bad state.