### PR TITLE
Fix maintained hooks update bug :anchor:

### DIFF
--- a/githooks/cmd/common/install/wrappers.go
+++ b/githooks/cmd/common/install/wrappers.go
@@ -35,7 +35,7 @@ func InstallIntoRepo(
 	isBare := gitxR.IsBareRepo()
 
 	var err error
-	if hookNames == nil {
+	if len(hookNames) == 0 {
 		hookNames, err = hooks.GetMaintainedHooks(gitxR, git.Traverse)
 		log.AssertNoErrorF(err, "Could not get maintained hooks.")
 	}

--- a/githooks/cmd/installer/installer.go
+++ b/githooks/cmd/installer/installer.go
@@ -842,13 +842,10 @@ func setupHookTemplates(
 		return // nolint:nlreturn
 	}
 
-	log.InfoF("Installing Git hook templates into '%s'.",
-		hookTemplateDir)
-
 	log.InfoF("Saving Githooks run-wrapper to '%s' :", hookTemplateDir)
 
 	var err error
-	if maintainedHooks == nil {
+	if len(maintainedHooks) == 0 {
 		maintainedHooks, err = hooks.GetMaintainedHooks(gitx, git.GlobalScope)
 		log.AssertNoError(err, "Could not get config.")
 	}

--- a/githooks/git/gitconfig-cache_test.go
+++ b/githooks/git/gitconfig-cache_test.go
@@ -16,15 +16,18 @@ func TestGitConfigCache(t *testing.T) {
 		"\x00local\x00a.a\na2" +
 		"\x00local\x00a.b\na3.1\na3.2\na3.3" +
 		"\x00local\x00a.c\nc1\x00\x00\x00\x00" +
-		"\x00global\x00a.a\na3"
+		"\x00global\x00a.a\na3" +
+		"\x00command\x00t.t\na3"
 
 	c, err := parseConfig(s, func(string) bool { return true })
 
-	local := c.scopes[0]
-	global := c.scopes[1]
-	system := c.scopes[2]
+	command := c.scopes[0]
+	local := c.scopes[1]
+	global := c.scopes[2]
+	system := c.scopes[3]
 
 	assert.Nil(t, err)
+	assert.Equal(t, 1, len(command))
 	assert.Equal(t, 1, len(system))
 	assert.Equal(t, 2, len(global))
 	assert.Equal(t, 3, len(local))

--- a/githooks/hooks/hook-names.go
+++ b/githooks/hooks/hook-names.go
@@ -132,7 +132,7 @@ func getMaintainedHooksFromString(maintainedHooks string) (hookNames []string, e
 
 	if err != nil {
 		err = cm.CombineErrors(err,
-			cm.ErrorF("Maintained hooks '%s' is not valid.", maintainedHooks))
+			cm.ErrorF("Maintained hooks '%s' is not valid. Fallback to all hooks.", maintainedHooks))
 
 		return ManagedHookNames, err
 	}
@@ -145,17 +145,7 @@ func getMaintainedHooksFromString(maintainedHooks string) (hookNames []string, e
 func GetMaintainedHooks(
 	gitx *git.Context,
 	scope git.ConfigScope) (hookNames []string, err error) {
-
 	h := git.NewCtx().GetConfig(GitCKMaintainedHooks, scope)
-
-	if err != nil {
-		err = cm.CombineErrors(err, cm.ErrorF("Could not read maintained hooks from Git config '%s'.\n"+
-			"  cwd: '%s'\n"+
-			"-> Fallback to all supported hooks.",
-			GitCKMaintainedHooks, gitx.GetCwd()))
-
-		return ManagedHookNames, err
-	}
 
 	return getMaintainedHooksFromString(h)
 

--- a/githooks/hooks/wrapper.go
+++ b/githooks/hooks/wrapper.go
@@ -328,7 +328,7 @@ func reinstallLFSHooks(
 	hookNames []string,
 	lfsHooksCache LFSHooksCache) (count int, err error) {
 
-	if hookNames == nil {
+	if len(hookNames) == 0 {
 		return
 	}
 


### PR DESCRIPTION
- Maintained hooks not read from global config during update.
- Fix `command` scope in Git config cache.