### PR TITLE
Fix leaking `GIT_DIR` due to `git hooks ...` :anchor:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 jobs:
   linux:
-    resource_class: small
+    resource_class: medium
     parameters:
       test:
         description: "The test script name"

--- a/githooks/cmd/installer/installer.go
+++ b/githooks/cmd/installer/installer.go
@@ -282,7 +282,7 @@ func buildFromSource(
 
 	// Checkout the remote commit sha
 	log.InfoF("Checkout out commit '%s'", commitSHA[0:6])
-	gitx := git.NewCtxAt(tempDir)
+	gitx := git.NewCtxSanitizedAt(tempDir)
 	err = gitx.Check("checkout",
 		"-b", "update-to-"+commitSHA[0:6],
 		commitSHA)

--- a/githooks/cmd/root.go
+++ b/githooks/cmd/root.go
@@ -34,10 +34,13 @@ func NewSettings(
 
 	var promptx prompt.IContext
 	var err error
-
 	cwd, err := os.Getwd()
-	gitx := git.NewCtxAt(cwd)
 	log.AssertNoErrorPanic(err, "Could not get current working directory.")
+
+	// Since this CLI is executed over `git ...` it sets
+	// environement variables we are not interested in when running this executable.
+	log.AssertNoError(git.SanitizeOsEnv(), "Could not sanitize OS environement.")
+	gitx := git.NewCtx()
 
 	installDir := inst.LoadInstallDir(log, gitx)
 

--- a/githooks/cmd/root.go
+++ b/githooks/cmd/root.go
@@ -38,8 +38,8 @@ func NewSettings(
 	log.AssertNoErrorPanic(err, "Could not get current working directory.")
 
 	// Since this CLI is executed over `git ...` it sets
-	// environement variables we are not interested in when running this executable.
-	log.AssertNoError(git.SanitizeOsEnv(), "Could not sanitize OS environement.")
+	// environment variables we are not interested in when running this executable.
+	log.AssertNoError(git.SanitizeOsEnv(), "Could not sanitize OS environment.")
 	gitx := git.NewCtx()
 
 	installDir := inst.LoadInstallDir(log, gitx)

--- a/githooks/git/git.go
+++ b/githooks/git/git.go
@@ -254,3 +254,12 @@ func SanitizeEnv(env []string) []string {
 			!strings.Contains(s, "GIT_WORK_TREE")
 	})
 }
+
+// SanitizeOsEnv santizes the process environement from unwanted Git (possibly leaking)
+// Git variables which might interfere with certain buggy Git commands.
+func SanitizeOsEnv() error {
+	err := os.Unsetenv("GIT_DIR")
+	err = cm.CombineErrors(err, os.Unsetenv("GIT_WORK_TREE"))
+
+	return err
+}

--- a/githooks/hooks/lfs-hooks-cache.go
+++ b/githooks/hooks/lfs-hooks-cache.go
@@ -1,0 +1,134 @@
+package hooks
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	cm "github.com/gabyx/githooks/githooks/common"
+	"github.com/gabyx/githooks/githooks/git"
+	"github.com/hashicorp/go-version"
+)
+
+// A file cache containing LFS hooks.
+type LFSHooksCache interface {
+	// Returns all LFS paths and file names inside the cache.
+	GetLFSHooks() ([]string, []string, error)
+}
+
+type lfsHooksCache struct {
+	lfsHookNames       []string
+	repoDir            string
+	requiredLFSVersion *version.Version
+	initialized        bool
+
+	failure error
+}
+
+// Returns all LFS paths and file names inside the cache.
+func (l *lfsHooksCache) GetLFSHooks() ([]string, []string, error) {
+	if !l.initialized && l.failure == nil {
+		l.failure = l.init()
+	}
+
+	if l.failure != nil {
+		return nil, nil, l.failure
+	}
+
+	lfsHookFiles := make([]string, len(l.lfsHookNames))
+	for i := range l.lfsHookNames {
+		f := path.Join(l.repoDir, "hooks", l.lfsHookNames[i])
+		if cm.IsFile(f) {
+			lfsHookFiles[i] = f
+		}
+	}
+
+	return lfsHookFiles, l.lfsHookNames, nil
+}
+
+// Creates a new LFS hooks cache.
+func NewLFSHooksCache(tempDir string) (_ LFSHooksCache, err error) {
+	if !git.IsLFSAvailable() {
+		return nil, nil
+	}
+
+	var l lfsHooksCache
+	l.repoDir = path.Join(tempDir, "lfs-hooks")
+	l.requiredLFSVersion, err = git.GetGitLFSVersion()
+
+	return &l, err
+}
+
+func gitLFSInstall(gitx *git.Context) (err error) {
+	err = gitx.Check("lfs", "install")
+
+	if err != nil {
+		err = cm.CombineErrors(err, cm.ErrorF("Could not install Git LFS hooks in\n"+
+			"'%s'.\n"+
+			"Please try manually by invoking:\n"+
+			"  $ git -C '%[1]s' lfs install", gitx.GetCwd()))
+	}
+
+	return
+}
+
+// Initializes the cache.
+func (l *lfsHooksCache) init() (err error) {
+
+	if l.initialized {
+		return nil
+	}
+
+	versionFile := path.Join(l.repoDir, "lfs-version.info")
+
+	reinit := true
+
+	if cm.IsFile(versionFile) {
+		ver, err := os.ReadFile(versionFile)
+		if err == nil {
+			v, err := version.NewVersion(strings.TrimSpace(string(ver)))
+			reinit = err != nil || !v.Equal(l.requiredLFSVersion)
+		}
+	}
+
+	gitx := git.NewCtxSanitizedAt(l.repoDir)
+	hooksDir := path.Join(l.repoDir, "hooks")
+	if !cm.IsDirectory(hooksDir) || !gitx.IsGitRepo() {
+		reinit = true
+	}
+
+	if reinit {
+		err = os.MkdirAll(l.repoDir, cm.DefaultFileModeDirectory)
+
+		if err != nil {
+			return cm.CombineErrors(err, cm.ErrorF("Could not create LFS hooks cache in '%s'.", l.repoDir))
+		}
+
+		err = git.Init(l.repoDir, true)
+		if err != nil {
+			return
+		}
+
+		err = gitLFSInstall(gitx)
+		if err != nil {
+			return
+		}
+	}
+
+	for i := range ManagedHookNames {
+		hook := path.Join(l.repoDir, "hooks", ManagedHookNames[i])
+		if cm.IsFile(hook) {
+			l.lfsHookNames = append(l.lfsHookNames, ManagedHookNames[i])
+		}
+	}
+
+	err = ioutil.WriteFile(versionFile, []byte(l.requiredLFSVersion.String()), cm.DefaultFileModeFile)
+	if err != nil {
+		err = cm.CombineErrors(err, cm.ErrorF("Could not write version file in LFS hooks cache '%s'.", l.repoDir))
+	}
+
+	l.initialized = true
+
+	return
+}

--- a/githooks/hooks/wrapper.go
+++ b/githooks/hooks/wrapper.go
@@ -1,7 +1,6 @@
 package hooks
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -10,9 +9,7 @@ import (
 
 	"github.com/gabyx/githooks/githooks/build"
 	cm "github.com/gabyx/githooks/githooks/common"
-	"github.com/gabyx/githooks/githooks/git"
 	strs "github.com/gabyx/githooks/githooks/strings"
-	"github.com/hashicorp/go-version"
 )
 
 var runWrapperDetectionRegex = regexp.MustCompile(`https://github\.com/(gabyx|rycus86)/githooks`)
@@ -378,127 +375,6 @@ func reinstallLFSHooks(
 			continue
 		}
 	}
-
-	return
-}
-
-// A file cache containing LFS hooks.
-type LFSHooksCache interface {
-	// Returns all LFS paths and file names inside the cache.
-	GetLFSHooks() ([]string, []string, error)
-}
-
-type lfsHooksCache struct {
-	lfsHookNames       []string
-	repoDir            string
-	requiredLFSVersion *version.Version
-	initialized        bool
-
-	failure error
-}
-
-// Returns all LFS paths and file names inside the cache.
-func (l *lfsHooksCache) GetLFSHooks() ([]string, []string, error) {
-	if !l.initialized && l.failure == nil {
-		l.failure = l.init()
-	}
-
-	if l.failure != nil {
-		return nil, nil, l.failure
-	}
-
-	lfsHookFiles := make([]string, len(l.lfsHookNames))
-	for i := range l.lfsHookNames {
-		f := path.Join(l.repoDir, "hooks", l.lfsHookNames[i])
-		if cm.IsFile(f) {
-			lfsHookFiles[i] = f
-		}
-	}
-
-	return lfsHookFiles, l.lfsHookNames, nil
-}
-
-// Creates a new LFS hooks cache.
-func NewLFSHooksCache(tempDir string) (_ LFSHooksCache, err error) {
-	if !git.IsLFSAvailable() {
-		return nil, nil
-	}
-
-	var l lfsHooksCache
-	l.repoDir = path.Join(tempDir, "lfs-hooks")
-	l.requiredLFSVersion, err = git.GetGitLFSVersion()
-
-	return &l, err
-}
-
-func gitLFSInstall(gitDir string) (err error) {
-	err = git.NewCtxAt(gitDir).Check("lfs", "install")
-
-	if err != nil {
-		err = cm.CombineErrors(err, cm.ErrorF("Could not install Git LFS hooks in\n"+
-			"'%s'.\n"+
-			"Please try manually by invoking:\n"+
-			"  $ git -C '%[1]s' lfs install", gitDir))
-	}
-
-	return
-}
-
-// Initializes the cache.
-func (l *lfsHooksCache) init() (err error) {
-
-	if l.initialized {
-		return nil
-	}
-
-	versionFile := path.Join(l.repoDir, "lfs-version.info")
-
-	reinit := true
-
-	if cm.IsFile(versionFile) {
-		ver, err := os.ReadFile(versionFile)
-		if err == nil {
-			v, err := version.NewVersion(strings.TrimSpace(string(ver)))
-			reinit = err != nil || !v.Equal(l.requiredLFSVersion)
-		}
-	}
-
-	hooksDir := path.Join(l.repoDir, "hooks")
-	if !cm.IsDirectory(hooksDir) || !git.NewCtxAt(l.repoDir).IsGitRepo() {
-		reinit = true
-	}
-
-	if reinit {
-		err = os.MkdirAll(l.repoDir, cm.DefaultFileModeDirectory)
-
-		if err != nil {
-			return cm.CombineErrors(err, cm.ErrorF("Could not create LFS hooks cache in '%s'.", l.repoDir))
-		}
-
-		err = git.Init(l.repoDir, true)
-		if err != nil {
-			return
-		}
-
-		err = gitLFSInstall(l.repoDir)
-		if err != nil {
-			return
-		}
-	}
-
-	for i := range ManagedHookNames {
-		hook := path.Join(l.repoDir, "hooks", ManagedHookNames[i])
-		if cm.IsFile(hook) {
-			l.lfsHookNames = append(l.lfsHookNames, ManagedHookNames[i])
-		}
-	}
-
-	err = ioutil.WriteFile(versionFile, []byte(l.requiredLFSVersion.String()), cm.DefaultFileModeFile)
-	if err != nil {
-		err = cm.CombineErrors(err, cm.ErrorF("Could not write version file in LFS hooks cache '%s'.", l.repoDir))
-	}
-
-	l.initialized = true
 
 	return
 }

--- a/githooks/tools/generate-version.go
+++ b/githooks/tools/generate-version.go
@@ -37,7 +37,7 @@ func GetBuildVersion() *version.Version {
 
 func main() {
 
-	gitx := git.NewCtx()
+	gitx := git.NewCtxSanitized()
 
 	root, err := gitx.Get("rev-parse", "--show-toplevel")
 	cm.AssertNoErrorPanicF(err, "Could not root dir.")


### PR DESCRIPTION
- Fixes various problems when running the CLI over `git hooks` and Git sets the `GIT_DIR` 
  when randomly inside a `.git` directory.