### PR TITLE
feat: Use env. variable to change `.githooks` hook dir name

### DIFF
--- a/githooks/hooks/githooks.go
+++ b/githooks/hooks/githooks.go
@@ -14,6 +14,7 @@ import (
 
 // HooksDirName denotes the directory name used for repository specific hooks.
 const HooksDirName = ".githooks"
+const HooksDirNameShared = "githooks"
 
 // GithooksWebpage is the main Githooks webpage.
 const GithooksWebpage = "https://github.com/gabyx/githooks"
@@ -150,7 +151,7 @@ func GetSharedGithooksDir(repoDir string) (dir string) {
 	// This is second, to allow internal development Githooks inside shared repos.
 	// 3. Fallback to the whole repository.
 
-	if dir = path.Join(repoDir, "githooks"); cm.IsDirectory(dir) {
+	if dir = path.Join(repoDir, HooksDirNameShared); cm.IsDirectory(dir) {
 		return
 	} else if dir = GetGithooksDir(repoDir); cm.IsDirectory(dir) {
 		return

--- a/githooks/hooks/githooks.go
+++ b/githooks/hooks/githooks.go
@@ -140,16 +140,35 @@ func CheckGithooksSetup(gitx *git.Context) (err error) {
 
 // GetGithooksDir gets the hooks directory for Githooks inside a repository (bare, non-bare).
 func GetGithooksDir(repoDir string) string {
+
+	// 0. priority has ".${GITHOOKS_HOOKS_DIR_NAME}"
+	// 1. priority has ".githooks"
+
+	if name := os.Getenv("GITHOOKS_HOOKS_DIR_NAME"); strs.IsNotEmpty(name) {
+		name = "." + strings.TrimPrefix(".", name) // nolint: gocritic
+		if dir := path.Join(repoDir, name); cm.IsDirectory(dir) {
+			return dir
+		}
+	}
+
 	return path.Join(repoDir, HooksDirName)
 }
 
 // GetSharedGithooksDir gets the hooks directory for Githooks inside a shared repository.
 func GetSharedGithooksDir(repoDir string) (dir string) {
 
+	// 0. priority has ".${GITHOOKS_HOOKS_DIR_NAME}"
 	// 1. priority has non-dot folder 'githooks'
 	// 2. priority is the normal '.githooks' folder.
 	// This is second, to allow internal development Githooks inside shared repos.
 	// 3. Fallback to the whole repository.
+
+	if name := os.Getenv("GITHOOKS_HOOKS_DIR_NAME"); strs.IsNotEmpty(name) {
+		name = strings.TrimPrefix(".", name) // nolint: gocritic
+		if dir = path.Join(repoDir, name); cm.IsDirectory(dir) {
+			return
+		}
+	}
 
 	if dir = path.Join(repoDir, HooksDirNameShared); cm.IsDirectory(dir) {
 		return


### PR DESCRIPTION
- Use `GITHOOKS_HOOKS_DIR_NAME` env. variable overwrite the `.githooks` directory name for normal and shared repositories.
- Usage `GITHOOKS_HOOKS_DIR_NAME=mybla` will resolve `.mybla` in local repos and `mybla` and `.mybla` in shared repos.