### PR TITLE
fix: Auto install fails due env variable :anchor:

### DIFF
--- a/githooks/apps/runner/runner.go
+++ b/githooks/apps/runner/runner.go
@@ -342,14 +342,11 @@ func updateGithooks(settings *HookSettings, uiSettings *UISettings) {
 
 	if err != nil {
 		m := strs.Fmt(
-			"Running update failed.\n"+
-				"Error: '%v'\n"+
-				"See latest log '%s' !",
-			err,
+			"Running update failed. See latest log '%s' !",
 			path.Join(os.TempDir(),
 				"githooks-installer-*.log"))
 
-		log.Error(m)
+		log.AssertNoError(err, m)
 		err = uiSettings.PromptCtx.ShowMessage(m, true)
 		log.AssertNoError(err, "Could not show message.")
 

--- a/githooks/cmd/installer/installer.go
+++ b/githooks/cmd/installer/installer.go
@@ -533,8 +533,10 @@ func findGitHookTemplates(
 	log.PanicIfF(haveInstall,
 		"Your installation is corrupt.\n"+
 			"The global Git config 'githooks.useCoreHooksPath = %v'\n"+
-			"is set but the corresponding hook templates directory\n"+
-			"is not found. Is 'core.hooksPath' unset?", installUsesCoreHooksPath)
+			"is set (you have an install) but the corresponding\n"+
+			"hook templates directory is not found.\n"+
+			"If 'false', is 'init.templateDir' unset?\n"+
+			"Or if 'true', is 'core.hooksPath' unset?", installUsesCoreHooksPath)
 
 	// 4. Try setup new folder if running non-interactively
 	// and no folder is found by now

--- a/githooks/git/git.go
+++ b/githooks/git/git.go
@@ -247,7 +247,8 @@ func (c *Context) IsConfigSet(key string, scope ConfigScope) bool {
 func SanitizeEnv(env []string) []string {
 	return strs.Filter(env, func(s string) bool {
 		return !strings.Contains(s, "GIT_DIR") &&
-			!strings.Contains(s, "GIT_WORK_TREE")
+			!strings.Contains(s, "GIT_WORK_TREE") &&
+			!strings.Contains(s, "GIT_INDEX_FILE")
 	})
 }
 
@@ -256,6 +257,7 @@ func SanitizeEnv(env []string) []string {
 func SanitizeOsEnv() error {
 	err := os.Unsetenv("GIT_DIR")
 	err = cm.CombineErrors(err, os.Unsetenv("GIT_WORK_TREE"))
+	err = cm.CombineErrors(err, os.Unsetenv("GIT_INDEX_FILE"))
 
 	return err
 }

--- a/githooks/git/gitcommon.go
+++ b/githooks/git/gitcommon.go
@@ -377,9 +377,9 @@ func FetchOrClone(
 	url string, branch string,
 	depth int,
 	tagPattern string,
-	repoCheck RepoCheck) (isNewClone bool, err error) {
+	repoCheck RepoCheck) (isNewClone bool, gitx *Context, err error) {
 
-	gitx := NewCtxSanitizedAt(repoPath)
+	gitx = NewCtxSanitizedAt(repoPath)
 
 	if gitx.IsGitRepo() {
 		isNewClone = false

--- a/githooks/updates/updates.go
+++ b/githooks/updates/updates.go
@@ -235,12 +235,10 @@ func FetchUpdates(
 	// Fetch the whole branch because we need it.
 	// The head could be in between tags which we avoid by this.
 	depth := -1
-	isNewClone, err := git.FetchOrClone(cloneDir, url, branch, depth, "v*", check)
+	isNewClone, gitx, err := git.FetchOrClone(cloneDir, url, branch, depth, "v*", check)
 	if err != nil {
 		return
 	}
-
-	gitx := git.NewCtxSanitizedAt(cloneDir)
 
 	// If branch was empty (default branch), determine it now.
 	if strs.IsEmpty(branch) {


### PR DESCRIPTION
`git diff-index` fails due to set `GIT_INDEX_FILE` which is set from post-commit hook which will crash `RunUpdate` in
checking the status in the release clone.