### PR TITLE
fix(installer): correct uname option

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -99,7 +99,7 @@ function getPlatformArch() {
     elif uname -m | grep -q "aarch64" &>/dev/null; then
         _arch="arm64"
         return 0
-    elif uname -p | grep -q "arm64" &>/dev/null; then
+    elif uname -m | grep -q "arm64" &>/dev/null; then
         _arch="arm64"
     else
         die "Architecture: '$(uname -m)' not supported."


### PR DESCRIPTION
Partially fix #126 

`uname -p` return `arm` on a mac os with `arm64` and the check fails.
I cannot test on other ARM platform currently.