### PR TITLE
fix: Remove timestamp from git config :anchor:

### DIFF
--- a/githooks/apps/runner/runner.go
+++ b/githooks/apps/runner/runner.go
@@ -380,7 +380,7 @@ func shouldRunUpdateCheck(settings *HookSettings) bool {
 		return false
 	}
 
-	lastUpdateCheck, _, err := updates.GetUpdateCheckTimestamp(settings.GitX)
+	lastUpdateCheck, _, err := updates.GetUpdateCheckTimestamp(settings.InstallDir)
 	log.AssertNoErrorF(err, "Could get last update check time.")
 
 	return time.Since(lastUpdateCheck).Hours() > 24.0 //nolint: gomnd

--- a/githooks/cmd/config/config.go
+++ b/githooks/cmd/config/config.go
@@ -346,12 +346,12 @@ func runUpdateTime(ctx *ccm.CmdContext, opts *SetOptions) {
 
 	switch {
 	case opts.Reset:
-		err := updates.ResetUpdateCheckTimestamp()
+		err := updates.ResetUpdateCheckTimestamp(ctx.InstallDir)
 		ctx.Log.AssertNoErrorPanicF(err, "Could not reset %s.", text)
 		ctx.Log.InfoF("Reset %s.", text)
 
 	case opts.Print:
-		ts, isSet, err := updates.GetUpdateCheckTimestamp(ctx.GitX)
+		ts, isSet, err := updates.GetUpdateCheckTimestamp(ctx.InstallDir)
 		ctx.Log.AssertNoErrorPanic(err, "Could not get %s.", text)
 		if isSet {
 			ctx.Log.InfoF("%s set to '%s'.", ts.Format(time.RFC1123))

--- a/githooks/cmd/uninstaller/uninstaller.go
+++ b/githooks/cmd/uninstaller/uninstaller.go
@@ -316,6 +316,9 @@ func cleanGitConfig(log cm.ILogContext, gitx *git.Context) {
 	k = "githooks.maintainOnlyServerHooks"
 	log.AssertNoErrorF(gitx.UnsetConfig(k, git.GlobalScope),
 		"Could not unset global Git config '%s'.", k)
+	k = "githooks.autoUpdateCheckTimestamp"
+	log.AssertNoErrorF(gitx.UnsetConfig(k, git.GlobalScope),
+		"Could not unset global Git config '%s'.", k)
 }
 
 func cleanRegister(log cm.ILogContext, installDir string) {

--- a/githooks/hooks/gitconfig.go
+++ b/githooks/hooks/gitconfig.go
@@ -8,9 +8,8 @@ const (
 
 	GitCKDisable = "githooks.disable"
 
-	GitCKAutoUpdateEnabled        = "githooks.autoUpdateEnabled"
-	GitCKAutoUpdateCheckTimestamp = "githooks.autoUpdateCheckTimestamp"
-	GitCKAutoUpdateUsePrerelease  = "githooks.autoUpdateUsePrerelease"
+	GitCKAutoUpdateEnabled       = "githooks.autoUpdateEnabled"
+	GitCKAutoUpdateUsePrerelease = "githooks.autoUpdateUsePrerelease"
 
 	GitCKBugReportInfo = "githooks.bugReportInfo"
 
@@ -72,7 +71,6 @@ func GetGlobalGitConfigKeys() []string {
 		GitCKPreviousSearchDir,
 
 		GitCKAutoUpdateEnabled,
-		GitCKAutoUpdateCheckTimestamp,
 		GitCKAutoUpdateUsePrerelease,
 
 		GitCKBugReportInfo,

--- a/githooks/scripts/clean-install.sh
+++ b/githooks/scripts/clean-install.sh
@@ -6,7 +6,6 @@ git config --global --unset-all githooks.shared
 git config --global --unset githooks.failOnNonExistingSharedHooks
 git config --global --unset githooks.maintainedHooks
 git config --global --unset githooks.autoUpdateEnabled
-git config --global --unset githooks.autoUpdateCheckTimestamp
 git config --global --unset githooks.cloneUrl
 git config --global --unset githooks.cloneBranch
 git config --global --unset githooks.previousSearchDir

--- a/githooks/updates/timestamp.go
+++ b/githooks/updates/timestamp.go
@@ -2,38 +2,73 @@ package updates
 
 import (
 	"fmt"
+	"os"
+	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	cm "github.com/gabyx/githooks/githooks/common"
-	"github.com/gabyx/githooks/githooks/git"
-	"github.com/gabyx/githooks/githooks/hooks"
 	strs "github.com/gabyx/githooks/githooks/strings"
 )
 
+var lastUpdateTimeStampFilename = ".last-update-check-timestamp"
+
+func getUpdateCheckTimestampFile(installDir string) string {
+	return path.Join(installDir, lastUpdateTimeStampFilename)
+}
+
 // RecordUpdateCheckTimestamp records the current update check time.
-func RecordUpdateCheckTimestamp() error {
-	return git.NewCtx().SetConfig(hooks.GitCKAutoUpdateCheckTimestamp,
-		fmt.Sprintf("%v", time.Now().Unix()), git.GlobalScope)
+func RecordUpdateCheckTimestamp(installDir string) error {
+	err := os.MkdirAll(installDir, cm.DefaultFileModeDirectory)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(
+		getUpdateCheckTimestampFile(installDir),
+		[]byte(fmt.Sprintf("%v", time.Now().Unix())),
+		cm.DefaultFileModeFile)
+
+	s, _, _ := GetUpdateCheckTimestamp(installDir)
+	fmt.Printf("TIMESTAMPE %s", s)
+
+	return err
 }
 
 // ResetUpdateCheckTimestamp resets the update check time.
-func ResetUpdateCheckTimestamp() error {
-	return git.NewCtx().UnsetConfig(hooks.GitCKAutoUpdateCheckTimestamp, git.GlobalScope)
+func ResetUpdateCheckTimestamp(installDir string) error {
+	_ = os.Remove(getUpdateCheckTimestampFile(installDir))
+
+	return nil
 }
 
 // GetUpdateCheckTimestamp gets the update check time.
-func GetUpdateCheckTimestamp(gitx *git.Context) (t time.Time, isSet bool, err error) {
+func GetUpdateCheckTimestamp(installDir string) (t time.Time, isSet bool, err error) {
 
 	// Initialize with too old time...
 	t = time.Unix(0, 0)
 
-	timeLastUpdateCheck := gitx.GetConfig(hooks.GitCKAutoUpdateCheckTimestamp, git.GlobalScope)
+	file := getUpdateCheckTimestampFile(installDir)
+	timeLastUpdateCheck := ""
+
+	if exists, _ := cm.IsPathExisting(file); exists {
+		var data []byte
+		data, err = os.ReadFile(getUpdateCheckTimestampFile(installDir))
+		if err != nil {
+			return
+		}
+
+		timeLastUpdateCheck = strings.TrimSpace(string(data))
+	} else {
+		return
+	}
+
 	if strs.IsEmpty(timeLastUpdateCheck) {
 		return
 	}
-	isSet = true
 
+	isSet = true
 	value, err := strconv.ParseInt(timeLastUpdateCheck, 10, 64) // nolint: gomnd
 	if err != nil {
 		err = cm.CombineErrors(cm.Error("Could not parse update time."), err)

--- a/githooks/updates/updates.go
+++ b/githooks/updates/updates.go
@@ -475,7 +475,7 @@ func RunUpdate(
 	usePreRelease bool,
 	run func() error) (updateAvailable bool, accepted bool, err error) {
 
-	err = RecordUpdateCheckTimestamp()
+	err = RecordUpdateCheckTimestamp(installDir)
 
 	if err != nil {
 		err = cm.Error("Could not record update check timestamp.")

--- a/tests/general.sh
+++ b/tests/general.sh
@@ -34,6 +34,25 @@ function assertNoTestImages() {
     fi
 }
 
+function setUpdateCheckTimestamp() {
+    mkdir -p "$GH_INSTALL_DIR"
+    echo "$1" >"$GH_INSTALL_DIR/.last-update-check-timestamp"
+    return 0
+}
+
+function getUpdateCheckTimestamp() {
+    file="$GH_INSTALL_DIR/.last-update-check-timestamp"
+    if [ -f "$file" ]; then
+        cat "$file"
+    fi
+
+    return 0
+}
+
+function resetUpdateCheckTimestamp() {
+    rm "$GH_INSTALL_DIR/.last-update-check-timestamp" || return 0
+}
+
 function deleteAllTestImages() {
     if ! isDockerAvailable; then
         return 0

--- a/tests/steps/step-029.sh
+++ b/tests/steps/step-029.sh
@@ -6,7 +6,7 @@ TEST_DIR=$(cd "$(dirname "$0")/.." && pwd)
 # shellcheck disable=SC1091
 . "$TEST_DIR/general.sh"
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -n "$LAST_UPDATE" ]; then
     echo "! Update already marked as run"
     exit 1
@@ -25,7 +25,7 @@ if ! git -C ~/.githooks/release rev-parse HEAD; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -z "$LAST_UPDATE" ]; then
     echo "! Update check did not run"
     exit 1

--- a/tests/steps/step-030.sh
+++ b/tests/steps/step-030.sh
@@ -20,7 +20,7 @@ if git -C ~/.githooks/release rev-parse HEAD; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -n "$LAST_UPDATE" ]; then
     echo "! Update unexpectedly run"
     exit 1

--- a/tests/steps/step-031.sh
+++ b/tests/steps/step-031.sh
@@ -9,7 +9,7 @@ TEST_DIR=$(cd "$(dirname "$0")/.." && pwd)
 CURRENT_TIME=$(date +%s)
 MOCK_LAST_RUN=$((CURRENT_TIME - 5))
 
-git config --global githooks.autoUpdateCheckTimestamp $MOCK_LAST_RUN || exit 1
+setUpdateCheckTimestamp "$MOCK_LAST_RUN" || exit 1
 
 mkdir -p "$GH_TEST_TMP/test31" &&
     cd "$GH_TEST_TMP/test31" &&
@@ -25,7 +25,7 @@ if git -C ~/.githooks/release rev-parse HEAD; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ "$LAST_UPDATE" != "$MOCK_LAST_RUN" ]; then
     echo "! Update did not behave as expected"
     exit 1

--- a/tests/steps/step-032.sh
+++ b/tests/steps/step-032.sh
@@ -22,7 +22,7 @@ if ! git -C ~/.githooks/release rev-parse HEAD; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -z "$LAST_UPDATE" ]; then
     echo "! Update check was expected to start"
     exit 1

--- a/tests/steps/step-042.sh
+++ b/tests/steps/step-042.sh
@@ -14,7 +14,7 @@ if echo "${EXTRA_INSTALL_ARGS:-}" | grep -q "use-core-hookspath"; then
     exit 249
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -n "$LAST_UPDATE" ]; then
     echo "! Update already marked as run"
     exit 1
@@ -40,7 +40,7 @@ if [ "$ARE_UPDATES_ENABLED" != "true" ]; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -n "$LAST_UPDATE" ]; then
     echo "! Update already marked as run"
     exit 1
@@ -52,7 +52,7 @@ if ! git -C "$GH_TEST_REPO" reset --hard v9.9.1 >/dev/null; then
     exit 1
 fi
 
-git config --global --unset githooks.autoUpdateCheckTimestamp
+resetUpdateCheckTimestamp
 
 OUTPUT=$(
     "$GH_INSTALL_BIN_DIR/runner" "$(pwd)"/.git/hooks/post-commit 2>&1
@@ -64,7 +64,7 @@ if ! echo "$OUTPUT" | grep -q "All done! Enjoy!"; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -z "$LAST_UPDATE" ]; then
     echo "! Update did not run"
     exit 1

--- a/tests/steps/step-045.sh
+++ b/tests/steps/step-045.sh
@@ -62,7 +62,7 @@ git -C "$GH_TEST_REPO" reset --hard v9.9.1 >/dev/null || {
 CURRENT="$(git -C ~/.githooks/release rev-parse HEAD)"
 cd "$GH_TEST_TMP/test045/001" &&
     git config --global githooks.autoUpdateEnabled true &&
-    git config --global githooks.autoUpdateCheckTimestamp $MOCK_LAST_RUN &&
+    setUpdateCheckTimestamp $MOCK_LAST_RUN &&
     OUT=$(git commit --allow-empty -m 'Second commit' 2>&1) || exit 1
 
 AFTER="$(git -C ~/.githooks/release rev-parse HEAD)"

--- a/tests/steps/step-076.sh
+++ b/tests/steps/step-076.sh
@@ -23,14 +23,14 @@ if ! git -C ~/.githooks/release rev-parse HEAD; then
     exit 1
 fi
 
-LAST_UPDATE=$(git config --global --get githooks.autoUpdateCheckTimestamp)
+LAST_UPDATE=$(getUpdateCheckTimestamp)
 if [ -z "$LAST_UPDATE" ]; then
     echo "! Update was expected to start"
     exit 1
 fi
 
 # 'git' is removed in 'hooks update disable'
-# due to covarage replacement issues.
+# due to coverage replacement issues.
 if ! echo "$OUTPUT" | grep -q "hooks update disable"; then
     echo "! Expected update output not found"
     echo "$OUTPUT"

--- a/tests/steps/step-087.sh
+++ b/tests/steps/step-087.sh
@@ -17,7 +17,7 @@ fi
 
 "$GH_INSTALL_BIN_DIR/cli" config update-time --print | grep -q 'never' || exit 3
 
-git config --global githooks.autoUpdateCheckTimestamp 123 &&
+setUpdateCheckTimestamp 123 &&
     "$GH_INSTALL_BIN_DIR/cli" config update-time --print | grep -q 'never' && exit 4
 
 "$GH_INSTALL_BIN_DIR/cli" config update-time --reset &&

--- a/tests/steps/step-116.sh
+++ b/tests/steps/step-116.sh
@@ -146,7 +146,7 @@ fi
 
 cd "$GH_TEST_TMP/test116.3" &&
     git config --global githooks.autoUpdateEnabled true &&
-    git config --global githooks.autoUpdateCheckTimestamp $MOCK_LAST_RUN &&
+    setUpdateCheckTimestamp $MOCK_LAST_RUN &&
     git commit --allow-empty -m 'Second commit' || exit 1
 
 # Check that all hooks are updated


### PR DESCRIPTION
Remove timestamp from Git config because its annoying to store it there.
Fixes #131.