### PR TITLE
feat: Add expansion of env. variables in Git config :anchor:

### DIFF
--- a/githooks/git/git.go
+++ b/githooks/git/git.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	HEAD string = "HEAD"
+	HEAD            string = "HEAD"
+	GitConfigPrefix string = "githooks."
 )
 
 // Context defines the context to execute it commands.
@@ -45,7 +46,9 @@ func NewCtxSanitized() *Context {
 	return NewCtxSanitizedAt("")
 }
 
-// SetConfigCache sets the Git config cache to use.
+// SetConfigCache sets the Git config cache to use where
+// all env. variables are replaced when `envReplacePrefix` matches the
+// key.
 func (c *Context) InitConfigCache(filter func(string) bool) error {
 	cache, err := NewConfigCache(*c, filter)
 
@@ -76,6 +79,11 @@ func (c *Context) GetConfig(key string, scope ConfigScope) (val string) {
 
 	if err != nil {
 		return ""
+	}
+
+	// Expand env. variables in Git config values.
+	if strings.HasPrefix(val, GitConfigPrefix) {
+		val = os.ExpandEnv(val)
 	}
 
 	return

--- a/githooks/git/gitconfig-cache.go
+++ b/githooks/git/gitconfig-cache.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bufio"
+	"os"
 	"regexp"
 	"strings"
 
@@ -121,6 +122,11 @@ func parseConfig(s string, filterFunc func(string) bool) (c ConfigCache, err err
 		if len(keyValue) != 2 ||
 			(filterFunc != nil && !filterFunc(keyValue[0])) { // nolint: gomnd
 			return
+		}
+
+		// Expand env. variables in Git config values.
+		if strings.HasPrefix(keyValue[0], GitConfigPrefix) {
+			keyValue[1] = os.ExpandEnv(keyValue[1])
 		}
 
 		c.add(keyValue[0], keyValue[0], keyValue[1], scope, false)

--- a/githooks/hooks/gitconfig_test.go
+++ b/githooks/hooks/gitconfig_test.go
@@ -1,0 +1,13 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gabyx/githooks/githooks/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitConfigPrefix(t *testing.T) {
+	assert.True(t, strings.HasPrefix(GitCKInstallDir, git.GitConfigPrefix))
+}


### PR DESCRIPTION
- Expansion only for `githooks.` prefixed variables.