### PR TITLE
feat: Add runtime logging with  env. variable `GITHOOKS_LOG_LEVEL` :anchor:

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ not globally be defined.
 | `GITHOOKS_CONTAINER_RUN` (defined by Githooks) | If a hook is run over a container, this variable is set and `true`                                                        |
 | `GITHOOKS_DISABLE`                             | If defined, disables running hooks run by Githooks,<br>except `git lfs` and the replaced old hooks.                       |
 | `GITHOOKS_RUNNER_TRACE`                        | If defined, enables tracing during <br>Githooks runner execution. A value of `1` enables more output.                     |
+| `GITHOOKS_LOG_LEVEL`                           | A value `debug`, `info`, `warn`, `error` or `disable` sets the log level during <br>Githooks runner execution.            |
 | `GITHOOKS_SKIP_NON_EXISTING_SHARED_HOOKS=true` | Skips on `true` and fails on `false` (or empty) for non-existing shared hooks. <br>See [Trusting Hooks](#trusting-hooks). |
 | `GITHOOKS_SKIP_UNTRUSTED_HOOKS=true`           | Skips on `true` and fails on `false` (or empty) for untrusted hooks. <br>See [Trusting Hooks](#trusting-hooks).           |
 

--- a/githooks/apps/cli/cli.go
+++ b/githooks/apps/cli/cli.go
@@ -28,7 +28,7 @@ func installSignalHandling() *cm.InterruptContext {
 
 func mainRun(cleanUpX *cm.InterruptContext) (exitCode int) {
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	cm.AssertOrPanic(err == nil, "Could not create log")
 
 	exitCode = 1

--- a/githooks/apps/dialog/dialog.go
+++ b/githooks/apps/dialog/dialog.go
@@ -29,7 +29,7 @@ func mainRun() (exitCode int) {
 	// ===============================================================
 
 	// We only log to stderr, because we need stdout for the output.
-	log, err := cm.CreateLogContext(true)
+	log, err := cm.CreateLogContext(true, false)
 	cm.AssertOrPanic(err == nil, "Could not create log")
 
 	// Handle all panics and report the error

--- a/githooks/apps/dialog/tools/generate-doc.go
+++ b/githooks/apps/dialog/tools/generate-doc.go
@@ -65,7 +65,7 @@ func main() {
 
 	docRoot := path.Join(root, "docs", "dialog")
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	cm.AssertNoErrorPanic(err, "Could not create log")
 
 	ctx := dcm.CmdContext{Log: log}

--- a/githooks/apps/runner/runner.go
+++ b/githooks/apps/runner/runner.go
@@ -112,7 +112,7 @@ func createLog() {
 	// might read stdin for certain hooks.
 	// Either do redirection (which needs to be bombproof)
 	// or just use stderr.
-	log, err = cm.CreateLogContext(true)
+	log, err = cm.CreateLogContext(true, true)
 	cm.AssertOrPanic(err == nil, "Could not create log")
 }
 

--- a/githooks/container/manager-container_test.go
+++ b/githooks/container/manager-container_test.go
@@ -61,7 +61,7 @@ RUN apk add bash
 	_, _ = io.WriteString(file, dockerfile)
 	file.Close()
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	assert.Nil(t, err)
 
 	exists, err := mgr.ImageExists("alpine:mine-special")
@@ -98,7 +98,7 @@ RUN apk add bashhhh
 	_, _ = io.WriteString(file, dockerfile)
 	file.Close()
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	assert.Nil(t, err)
 
 	_, err = mgr.ImageBuild(log, file.Name(), ".", "stage2", "alpine:mine-special")

--- a/githooks/hooks/images_test.go
+++ b/githooks/hooks/images_test.go
@@ -117,7 +117,7 @@ RUN apk add bash
 	err = os.WriteFile(path.Join(repo, ".githooks/docker/Dockerfile"), content, cm.DefaultFileModeFile)
 	assert.Nil(t, err)
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	assert.Nil(t, err)
 
 	err = UpdateImages(log, "test-repo", repo, path.Join(repo, ".githooks"), "")

--- a/githooks/prompt/show-gui-impl_test.go
+++ b/githooks/prompt/show-gui-impl_test.go
@@ -3,16 +3,17 @@
 package prompt_test
 
 import (
+	"os"
+
 	cm "github.com/gabyx/githooks/githooks/common"
 	"github.com/gabyx/githooks/githooks/prompt"
-	"os"
 
 	"testing"
 )
 
 func TestCoverage(t *testing.T) {
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	cm.AssertNoErrorPanic(err)
 
 	os.Stdin = nil

--- a/githooks/tools/generate-doc.go
+++ b/githooks/tools/generate-doc.go
@@ -70,7 +70,7 @@ func main() {
 
 	docRoot := path.Join(root, "docs", "cli")
 
-	log, err := cm.CreateLogContext(false)
+	log, err := cm.CreateLogContext(false, false)
 	cm.AssertNoErrorPanic(err, "Could not create log")
 
 	ctx := cmd.NewSettings(log, log, func() {}, nil)


### PR DESCRIPTION
- A value `debug`, `info`, `warn`, `error` or `disable` can be set in env. variable `GITHOOKS_LOG_LEVEL` to set the log level during runner execution.