### PR TITLE
fix: add no build if image exists + fix Git 2.46.x `git init` problem :anchor:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         default: "test-alpine"
         type: string
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run: bash tests/<<parameters.test>>.sh
@@ -30,12 +30,15 @@ jobs:
     executor:
       size: medium
       name: win/server-2022
-      version: 2023.11.1
+      version: current
     steps:
       - checkout
       - run:
           no_output_timeout: 30m
-          command: "& 'C:/Program Files/Git/bin/bash.exe' -c 'tests/<<parameters.test>>.sh --seq <<parameters.seq>>'"
+          command: >-
+            & 'C:/Program Files/Git/bin/bash.exe'
+            -c 'tests/<<parameters.test>>.sh
+            --seq <<parameters.seq>>'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,9 @@ workflows:
             branches:
               only: &task-branches
                 - /feature\/.*/
+                - /feat\/.*/
                 - /bugfix\/.*/
+                - /fix\/.*/
       - linux:
           matrix:
             parameters:

--- a/docs/cli/git_hooks_images_update.md
+++ b/docs/cli/git_hooks_images_update.md
@@ -18,6 +18,7 @@ git hooks images update
                         Useful to build images in shared repositories
                         `githooks/.images.yaml` directory.
                         Namespace is read from the current repository.
+  -b, --always-build    Always build images, even if they already exist.
   -h, --help            help for update
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702312524,
-        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
+        "lastModified": 1726463316,
+        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgsStable": {
       "locked": {
-        "lastModified": 1702233072,
-        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,41 +27,44 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    nixpkgsStable,
-    flake-utils,
-    ...
-  } @ inputs:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgsStable,
+      flake-utils,
+      ...
+    }@inputs:
     flake-utils.lib.eachDefaultSystem
-    # Creates an attribute map `{ devShells.<system>.default = ...}`
-    # by calling this function:
-    (
-      system: let
-        overlays = [];
+      # Creates an attribute map `{ devShells.<system>.default = ...}`
+      # by calling this function:
+      (
+        system:
+        let
+          overlays = [ ];
 
-        # Import nixpkgs and load it into pkgs.
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
+          # Import nixpkgs and load it into pkgs.
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
 
-        # Things needed only at compile-time.
-        nativeBuildInputs = with pkgs; [
-          go_1_21
-        ];
+          # Things needed only at compile-time.
+          nativeBuildInputs = with pkgs; [
+            go_1_22
+          ];
 
-        # Things needed at runtime.
-        buildInputs = with pkgs; [];
-      in
-        with pkgs; {
+          # Things needed at runtime.
+          buildInputs = with pkgs; [ ];
+        in
+        with pkgs;
+        {
           devShells.default = mkShell {
             # To make CGO and the debugger delve work.
             # https://nixos.wiki/wiki/Go#Using_cgo_on_NixOS
-            hardeningDisable = ["fortify"];
+            hardeningDisable = [ "fortify" ];
 
             inherit buildInputs nativeBuildInputs;
           };
         }
-    );
+      );
 }

--- a/githooks/apps/runner/runner.go
+++ b/githooks/apps/runner/runner.go
@@ -57,7 +57,13 @@ func mainRun() (exitCode int) {
 	cwd = filepath.ToSlash(cwd)
 
 	settings, uiSettings := setupSettings(cwd)
-	assertRegistered(settings.GitX, settings.InstallDir)
+
+	if settings.HookName != "reference-transaction" {
+		// Git 2.46.x apparently runs `reference-transaction` on `git init`
+		// where different commands fail like `git config ...` since
+		// the repo is not yet properly initialized (?).
+		assertRegistered(settings.GitX, settings.InstallDir)
+	}
 
 	checksums, err := hooks.GetChecksumStorage(settings.GitDirWorktree)
 	log.AssertNoErrorF(err, "Errors while loading checksum store.")
@@ -139,6 +145,9 @@ func setupSettings(repoPath string) (HookSettings, UISettings) {
 
 	// General execution context, in currenct working dir.
 	execx := cm.ExecContext{Env: os.Environ()}
+
+	log.DebugF("Arguments: '%q'", os.Args)
+	log.DebugF("Env: '%q'", os.Environ())
 
 	// Current git context, in current working dir.
 	gitx := git.NewCtxAt(repoPath)

--- a/githooks/apps/runner/runner.go
+++ b/githooks/apps/runner/runner.go
@@ -583,7 +583,8 @@ func updateLocalHookImages(settings *HookSettings) {
 		settings.RepositoryDir,
 		settings.RepositoryHooksDir,
 		"",
-		settings.ContainerMgr)
+		settings.ContainerMgr,
+		false)
 
 	log.AssertNoErrorF(e, "Could not updating container images from '%s'.", settings.HookDir)
 }

--- a/githooks/go.mod
+++ b/githooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/gabyx/githooks/githooks
 
-go 1.21
+go 1.22
 
 require (
 	code.gitea.io/sdk/gitea v0.15.0

--- a/githooks/hooks/gitconfig.go
+++ b/githooks/hooks/gitconfig.go
@@ -29,8 +29,6 @@ const (
 	GitCKNumThreads        = "githooks.numThreads"
 
 	GitCKAliasHooks = "alias.hooks"
-
-	GitCKBuildImagesOnSharedUpdate = "githooks.buildImagesOnSharedUpdate"
 )
 
 // Git config keys for local config.

--- a/githooks/hooks/images_test.go
+++ b/githooks/hooks/images_test.go
@@ -123,7 +123,7 @@ RUN apk add bash
 	mgr, err := container.NewManager("docker")
 	assert.Nil(t, err)
 	assert.NotNil(t, mgr)
-	err = UpdateImages(log, "test-repo", repo, path.Join(repo, ".githooks"), "", mgr)
+	err = UpdateImages(log, "test-repo", repo, path.Join(repo, ".githooks"), "", mgr, true)
 	assert.Nil(t, err, "Update images failed: %s", err)
 
 	mgr, err = container.NewManager("")

--- a/githooks/hooks/shared.go
+++ b/githooks/hooks/shared.go
@@ -471,7 +471,9 @@ func UpdateSharedHooks(
 				hook.OriginalURL,
 				hook.RepositoryDir,
 				GetSharedGithooksDir(hook.RepositoryDir),
-				"", containerMgr)
+				"",
+				containerMgr,
+				false)
 			log.AssertNoErrorF(e, "Updating container images of '%s' failed.", hook.OriginalURL)
 		}
 	}

--- a/tests/steps/step-006.sh
+++ b/tests/steps/step-006.sh
@@ -61,5 +61,8 @@ mkdir -p "$GH_TEST_TMP/test6" &&
 check_local_install_run_wrappers
 
 # Reinstall and check again.
-"$GH_INSTALL_BIN_DIR/githooks-cli" install
+"$GH_INSTALL_BIN_DIR/githooks-cli" install || {
+    echo "! Reinstall failed."
+    exit 1
+}
 check_local_install_run_wrappers

--- a/tests/test-alpine-nolfs.sh
+++ b/tests/test-alpine-nolfs.sh
@@ -11,7 +11,7 @@ TEST_DIR="$ROOT_DIR/tests"
 cd "$ROOT_DIR"
 
 cat <<EOF | docker build --force-rm -t githooks:alpine-nolfs-base -
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 RUN apk update && apk add git
 RUN apk add bash jq curl docker
 

--- a/tests/test-alpine.sh
+++ b/tests/test-alpine.sh
@@ -11,7 +11,7 @@ TEST_DIR="$ROOT_DIR/tests"
 cd "$ROOT_DIR"
 
 cat <<EOF | docker build --force-rm -t githooks:alpine-lfs-base -
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 RUN apk update && apk add git git-lfs
 RUN apk add bash jq curl docker
 

--- a/tests/test-centralized.sh
+++ b/tests/test-centralized.sh
@@ -11,7 +11,7 @@ TEST_DIR="$ROOT_DIR/tests"
 cd "$ROOT_DIR"
 
 cat <<EOF | docker build --force-rm -t githooks:alpine-lfs-centralized-base -
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 RUN apk update && apk add git git-lfs
 RUN apk add bash jq curl docker
 

--- a/tests/test-lint.sh
+++ b/tests/test-lint.sh
@@ -28,7 +28,7 @@ EOF
 
 # Build test container.
 cat <<EOF | docker build --force-rm -t githooks:test-rules -
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 RUN apk update && apk add git git-lfs
 RUN apk add bash jq curl docker just
 

--- a/tests/test-unittests.sh
+++ b/tests/test-unittests.sh
@@ -19,7 +19,7 @@ trap clean_up EXIT
 cd "$ROOT_DIR"
 
 cat <<EOF | docker build --force-rm -t githooks:unittests -
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 RUN apk update && apk add git git-lfs
 RUN apk add bash jq curl docker
 

--- a/tests/test-whitespace.sh
+++ b/tests/test-whitespace.sh
@@ -11,7 +11,7 @@ TEST_DIR="$ROOT_DIR/tests"
 cd "$ROOT_DIR"
 
 cat <<EOF | docker build --force-rm -t githooks:alpine-lfs-whitespace-base -
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 RUN apk update && apk add git git-lfs
 RUN apk add bash jq curl docker
 

--- a/tests/test-windows.sh
+++ b/tests/test-windows.sh
@@ -34,13 +34,13 @@ RUN $newPath = ('{0}\bin;C:\go\bin;{1}' -f $env:GOPATH, $env:PATH); \
 # doing this first to share cache across versions more aggressively
 
 # Check hash below for download.
-ENV GOLANG_VERSION 1.21.0
+ENV GOLANG_VERSION 1.22.7
 
 RUN $url = ('https://go.dev/dl/go{0}.windows-amd64.zip' -f $env:GOLANG_VERSION); \
     Write-Host ('Downloading {0} ...' -f $url); \
     $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri $url -OutFile 'go.zip'; \
     \
-    $sha256 = '732121e64e0ecb07c77fdf6cc1bc5ce7b242c2d40d4ac29021ad4c64a08731f6'; \
+    $sha256 = 'efbc30520601f4d91d9f3f46af03aafb2e1428388c5ff6a40eb88489f7212e85'; \
     Write-Host ('Verifying sha256 ({0}) ...' -f $sha256); \
     if ((Get-FileHash go.zip -Algorithm sha256).Hash -ne $sha256) { \
         Write-Host 'FAILED!'; \


### PR DESCRIPTION
Do not build images if they already exists with the same image reference. Add `--always-build` flag in CLI commands.