### PR TITLE
docs: fix nixos link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ successor of the [original implementation](https://github.com/rycus86/githooks)
 > This Git hook manager does **one job and only that**: running Git hooks. It
 > will **never** maintain your tools or support language toolchains and all
 > other sidestories you might have to make your hooks execute. There are
-> solutions to this like [Nix ❤️‍🔥](nixos.org) or container managers like `podman`
+> solutions to this like [Nix ❤️‍🔥](https://nixos.org/) or container managers like `podman`
 > (or `docker` -> don't).
 
 To make this work, the installer creates run-wrappers for Githooks that are


### PR DESCRIPTION
This currently opens `https://github.com/gabyx/Githooks/blob/main/nixos.org`.